### PR TITLE
Change `window` To `self`

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -390,7 +390,7 @@
             // no succeeded files, just skip
             return;
           }
-          window.setTimeout(function(){
+          self.setTimeout(function(){
             $.fire('filesAdded', files, filesSkipped);
           },0);
         }
@@ -440,7 +440,7 @@
             $.files.push(f);
             files.push(f);
             f.container = (typeof event != 'undefined' ? event.srcElement : null);
-            window.setTimeout(function(){
+            self.setTimeout(function(){
               $.fire('fileAdded', f, event)
             },0);
           })()} else {
@@ -559,12 +559,12 @@
         var round = $.getOpt('forceChunkSize') ? Math.ceil : Math.floor;
         var maxOffset = Math.max(round($.file.size/$.getOpt('chunkSize')),1);
         for (var offset=0; offset<maxOffset; offset++) {(function(offset){
-            window.setTimeout(function(){
+            self.setTimeout(function(){
                 $.chunks.push(new ResumableChunk($.resumableObj, $, offset, chunkEvent));
                 $.resumableObj.fire('chunkingProgress',$,offset/maxOffset);
             },0);
         })(offset)}
-        window.setTimeout(function(){
+        self.setTimeout(function(){
             $.resumableObj.fire('chunkingComplete',$);
         },0);
       };
@@ -1165,8 +1165,8 @@
       return Resumable;
     });
   } else {
-    // Browser: Expose to window
-    window.Resumable = Resumable;
+    // Browser: Expose to window or worker
+    self.Resumable = Resumable;
   }
 
 })();


### PR DESCRIPTION
Because when using `window` only web pages can use this. But when using `self`, then web workers can use it too.

### What's The Use?
I encountered this when I was trying to use the resumable file upload inside a web worker (I had to, because I needed some synchronous, blocking, pre-processing on the file) then all the window.* methods would blow up. Such scenario doesn't seem very improbable, considering the nature of files & IO.

### Backwards Compatible?
The "resumable.js" uses `window.setTimeout` in multiple cases and also `window.resumable = resumable` at the end of the file. As a matter of fact all these cases can be safely changed to `self.*` ([look here](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers)). I changed it and it seems to work both on web pages & web workers too. 